### PR TITLE
Fehler getsharedobject.mdx

### DIFF
--- a/docs/support/ESX/getsharedobject.mdx
+++ b/docs/support/ESX/getsharedobject.mdx
@@ -24,7 +24,7 @@ Das gezeigte Event kann in verschiedenen Skripten unterschiedlich implementiert 
 
 
 
-### ltes Event:
+### Altes Event:
 
 ```
 TriggerEvent("esx:getSharedObject", function(obj) ESX = obj end)


### PR DESCRIPTION
Rechtschreibfehler: ltes Event -> Altes Event